### PR TITLE
Added support for sanitization with context preservation

### DIFF
--- a/rules/har.yaml
+++ b/rules/har.yaml
@@ -6,7 +6,7 @@ rules:
         action: remove
     "$..headers..[?(@ && @.name == 'Cookie')][value]":
         description: Remove the Cookie header value.
-        action: remove
+        action: contextual_replacement
     "$..params..[?(@ && @.name == 'password')][value]":
         description: Remove the password param.
         action: remove

--- a/script/config.json
+++ b/script/config.json
@@ -11,5 +11,5 @@
     "renderNothingWhenEmpty": false
   },
   "SupportedFileExtensions":  ["har"],
-  "SupportedActions": ["remove"]
+  "SupportedActions": ["contextual_replacement", "remove"]
 }


### PR DESCRIPTION
## Description
Closes #15.
Added support for sanitization with context preservation

## Author's Checklist
- [x] **These changes don't break existing dependants.** If they do, and you suggest to proceed, 
please explain why.

## Reviewer's Checklist
- [ ] **All classes have documentation comments.** - NA
- [ ] **All methods have documentation comments.** - NA
- [x] **No parameters are hardcoded.** Should be loaded as properties instead. If there needs to be hardcoded properties, explain why.
- [ ] **All information to be logged/displayed to the user are internationalized.** If not, explain why.  - NA
- [ ] **README.md has been updated if needed.** - NA
- [ ] **pom.xml version is set to the latest date** If not, explain why. - NA

## Assignee's Checklist
- [ ] **All GitHub action checks have passed.** NA
- [x] **All reviewers have approved.**
- [x] **Relevant documentation has been updated if needed.**
- [ ] **pom.xml version is set to the latest date** If not, explain why. NA