### PR TITLE
Fix issues when no file input is chosen or an already sanitized file is chosen.

### DIFF
--- a/sanitize.go
+++ b/sanitize.go
@@ -6,6 +6,7 @@ import (
 	"github.com/PaesslerAG/jsonpath"
 	"github.com/tidwall/sjson"
 	"go/types"
+	"regexp"
 	"slices"
 	"strconv"
 	"strings"
@@ -13,17 +14,44 @@ import (
 
 var secretReplacementsMap = map[string]string{}
 
-func getSecretReplacement(secret string) string {
-	if secretReplacement, isPresent := secretReplacementsMap[secret]; isPresent {
-		println("Skipping contextual replacement as it has already been contextually sanitized.", secret, "=>", secretReplacement)
-		return secretReplacement
+func convertJsonPathToKey(jsonPath string) string {
+	jsonKey := strings.ReplaceAll(jsonPath, "\"][\"", ".")
+	jsonKey = strings.ReplaceAll(jsonKey, "$", "")
+	jsonKey = strings.ReplaceAll(jsonKey, "[", "")
+	jsonKey = strings.ReplaceAll(jsonKey, "]", "")
+	jsonKey = strings.ReplaceAll(jsonKey, "\"", "")
+	return jsonKey
+}
+
+func getSecretReplacement(secret string, secretPatterns []string, prefix string) (string, error) {
+	secretReplacement, isSecretReplacementPresent := secretReplacementsMap[secret]
+
+	// Check if secret has already been replaced.
+	// Need to consider the scenario when the secret pattern matches the actual secret.
+	isSecretAlreadyReplaced := false
+	for _, secretPattern := range secretPatterns {
+		match, err := regexp.MatchString(secretPattern, secret)
+		if err != nil {
+			return secretReplacement, nil
+		}
+		if match {
+			isSecretAlreadyReplaced = true
+		}
+	}
+
+	if isSecretReplacementPresent || isSecretAlreadyReplaced {
+		println("Skipping contextual replacement as it has already been sanitized.", secret, "=>", secretReplacement, ", isSecretReplacementPresent = ", isSecretReplacementPresent, ", isSecretAlreadyReplaced = ", isSecretAlreadyReplaced)
+		if isSecretAlreadyReplaced {
+			return secret, nil
+		}
+		return secretReplacement, nil
 	}
 	numberOfExistingSecretReplacements := len(secretReplacementsMap)
 
 	suffix := strconv.Itoa(numberOfExistingSecretReplacements + 1)
-	secretReplacement := "secret" + suffix
+	secretReplacement = prefix + suffix
 	secretReplacementsMap[secret] = secretReplacement
-	return secretReplacementsMap[secret]
+	return secretReplacementsMap[secret], nil
 }
 
 func Sanitize(content string, fileExtension string, ruleSets map[string]RuleSet, config Config) (string, error) {
@@ -44,8 +72,9 @@ func Sanitize(content string, fileExtension string, ruleSets map[string]RuleSet,
 	println("Format = ", ruleSet.Format)
 	println("Description = ", ruleSet.Description)
 	println("Rules = ", ruleSet.Rules)
+	replacementString := config.ReplacementString
+	secretPrefix := config.SecretPrefix
 	for ruleJsonPath, ruleInfo := range ruleSet.Rules {
-
 		println("ruleJsonPath = ", ruleJsonPath)
 		println("Description = ", ruleInfo.Description)
 		println("Action = ", ruleInfo.Action)
@@ -68,29 +97,24 @@ func Sanitize(content string, fileExtension string, ruleSets map[string]RuleSet,
 		if len(valuesMap) > 0 {
 			println("Rule hits:")
 			for jsonPath, value := range valuesMap {
-				jsonKey := strings.ReplaceAll(jsonPath, "\"][\"", ".")
-				jsonKey = strings.ReplaceAll(jsonKey, "$", "")
-				jsonKey = strings.ReplaceAll(jsonKey, "[", "")
-				jsonKey = strings.ReplaceAll(jsonKey, "]", "")
-				jsonKey = strings.ReplaceAll(jsonKey, "\"", "")
-
+				jsonKey := convertJsonPathToKey(jsonPath)
 				valueStr := value.(string)
 				println("\tjsonPath=", jsonPath, "jsonKey=", jsonKey, "value=", valueStr)
 				replacementValue := ""
 				if ruleInfo.Action == "contextual_replacement" {
-					replacementValue = getSecretReplacement(valueStr)
+					replacementValue, err = getSecretReplacement(valueStr, []string{replacementString, secretPrefix}, secretPrefix)
+					if err != nil {
+						errorFollowUp(err, false)
+					}
 				} else if ruleInfo.Action == "remove" {
-					replacementValue = "<REMOVED>"
+					replacementValue = replacementString
 				} else {
 					err = types.Error{Msg: "Unsupported action (" + ruleInfo.Action + ") for rule (" + ruleJsonPath + ")"}
 					errorFollowUp(err, false)
 				}
 				if replacementValue != "" {
-
-					//val := sjson.Get(sanitizedContent, jsonKey)
 					println("\t\tReplacement value is", replacementValue)
 					sanitizedContent, err = sjson.Set(sanitizedContent, jsonKey, replacementValue)
-					//sanitizedContent, err = sjson.Delete(sanitizedContent, jsonKey)
 					if err != nil {
 						errorFollowUp(err, false)
 					}

--- a/script/config.json
+++ b/script/config.json
@@ -10,6 +10,8 @@
     "highlight": true,
     "renderNothingWhenEmpty": false
   },
+  "ReplacementString": "<REMOVED>",
+  "SecretPrefix": "secret",
   "SupportedFileExtensions":  ["har"],
   "SupportedActions": ["contextual_replacement", "remove"]
 }

--- a/wasm_main.go
+++ b/wasm_main.go
@@ -15,6 +15,8 @@ import (
 )
 
 type Config struct {
+	ReplacementString       string   `json:"ReplacementString"`
+	SecretPrefix            string   `json:"SecretPrefix"`
 	SupportedFileExtensions []string `json:"SupportedFileExtensions"`
 	SupportedActions        []string `json:"SupportedActions"`
 }
@@ -87,7 +89,11 @@ func sanitizeCallback(_ js.Value, _ []js.Value) any {
 	Callback when an input file is selected to be sanitized.
 	*/
 	uploadButton := document.Call("getElementById", "upload_button")
-	file := uploadButton.Get("files").Call("item", 0)
+	files := uploadButton.Get("files")
+	if files.Get("length").Int() <= 0 {
+		return nil
+	}
+	file := files.Call("item", 0)
 	file.Call("arrayBuffer").Call("then", js.FuncOf(func(v js.Value, x []js.Value) any {
 		data := js.Global().Get("Uint8Array").New(x[0])
 		dst := make([]byte, data.Get("length").Int())


### PR DESCRIPTION
## Description

Closes #12.

When no file is chosen and the file input dialog is closed, the Go WASM code errors out and exits. This prevents any other file from being loaded and sanitized. Work around is to refresh the page so that the Go WASM code loads again. The desired behavior is, even if no file is selected, the Go WASM code doesn't errr out/exit and we're able to continue to load new files to sanitize without refreshing the page.

When an already sanitized file is opened, it sanitizes it with new secret replacements. The desired behavior is to detect if a field has already been sanitized and skip/sanitize accordingly.

## Author's Checklist
- [x] **These changes don't break existing dependants.** If they do, and you suggest to proceed, 
please explain why.

## Reviewer's Checklist
- [ ] **All classes have documentation comments.** - NA
- [x] **All methods have documentation comments.** - Simple/Straight forward methods don't have documentation comments.
- [x] **No parameters are hardcoded.** Should be loaded as properties instead. If there needs to be hardcoded properties, explain why.
- [ ] **All information to be logged/displayed to the user are internationalized.** If not, explain why. - NA
- [ ] **README.md has been updated if needed.** - NA
- [ ] **pom.xml version is set to the latest date** If not, explain why. - NA

## Assignee's Checklist
- [x] **All GitHub action checks have passed.**
- [ ] **All reviewers have approved.**
- [ ] **Relevant documentation has been updated if needed.**
- [ ] **pom.xml version is set to the latest date** If not, explain why.