### PR TITLE
Parallelize the secret detection logic

### DIFF
--- a/script/config.json
+++ b/script/config.json
@@ -10,7 +10,7 @@
     "highlight": true,
     "renderNothingWhenEmpty": false
   },
-  "ReplacementString": "<REMOVED>",
+  "RemovedSecretReplacement": "<REMOVED>",
   "SecretPrefix": "secret",
   "SupportedFileExtensions":  ["har"],
   "SupportedActions": ["contextual_replacement", "remove"]


### PR DESCRIPTION
## Description
Closes #25.

Parallelize the secret detection logic by running each detection rule as a separate go routine and aggregating the results in a channel. The actual sanitization cannot be parallelized as it needs to be done sequentially to ensure rule precedence i.e. the rule that is specified last overwrites the behavior of any matches from previous rules.

## Author's Checklist
- [x] **These changes don't break existing dependants.** If they do, and you suggest to proceed, 
please explain why.

## Reviewer's Checklist
- [ ] **All classes have documentation comments.** - NA
- [x] **All methods have documentation comments.**
- [x] **No parameters are hardcoded.** Should be loaded as properties instead. If there needs to be hardcoded properties, explain why.
- [ ] **All information to be logged/displayed to the user are internationalized.** If not, explain why.  -  NA
- [ ] **README.md has been updated if needed.** - NA
- [ ] **pom.xml version is set to the latest date** If not, explain why. - NA

## Assignee's Checklist
- [x] **All GitHub action checks have passed.**
- [x] **All reviewers have approved.**
- [x] **Relevant documentation has been updated if needed.**
- [ ] **pom.xml version is set to the latest date** If not, explain why.