### PR TITLE
Add support to sanitize multiple files at once.

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,8 @@ The following browsers are supported:
  - Google Chrome
  - Firefox
 
-At the moment, it sanitizes HAR files.
+At the moment, it sanitizes HAR files.<br>
+Multiple files can be sanitized at the same time.<br>
 Support for sanitizing SAML requests/responses are in progress.
 
 ## Build

--- a/index.html
+++ b/index.html
@@ -33,24 +33,23 @@
     <body onload="init()">
         <h1 id="title">Sensitive Info Sanitizer</h1>
         <div id="uploader">
-            <input type="file" id="upload_button" name="upload_button" class="form-control"/>
+            <input type="file" id="upload_button" name="upload_button" class="form-control" multiple="multiple"/>
         </div>
 
         <div id="display_panel" hidden>
             <div id="display_card" class="card">
                 <div id="buttons">
                     <input type="button" id="view_rules_button" class="btn btn-secondary" name="view_rules_button"
-                           value="View Rules File" disabled>
+                           value="View Rules File/s" disabled>
                     <input type="button" id="download_button" class="btn btn-success" name="download_button"
-                           value="Download Sanitized File" disabled>
+                           value="Download Sanitized File/s" disabled>
                 </div>
-                <div class="card-body">
+                <div id="output" class="card-body">
                     <div id="overlay-spinner">
                         <div class="w-100 d-flex justify-content-center align-items-center" id="spinner_container">
                             <div class="spinner-border text-success" id="spinner"></div>
                         </div>
                     </div>
-                    <div id="sanitized_diff_div"></div>
                 </div>
                 <div class="card-footer text-body-secondary" id="downloader"></div>
             </div>


### PR DESCRIPTION
## Description
Closes #27.

Added support to select multiple files as the input. When viewing the rule files, all the applicable rule files are opened in new tabs. When downloading the sanitized content, each file's sanitized content is a separate download.

## Author's Checklist
- [x] **These changes don't break existing dependants.** If they do, and you suggest to proceed, 
please explain why.

## Reviewer's Checklist
- [ ] **All classes have documentation comments.** - NA
- [ ] **All methods have documentation comments.** - NA
- [x] **No parameters are hardcoded.** Should be loaded as properties instead. If there needs to be hardcoded properties, explain why.
- [ ] **All information to be logged/displayed to the user are internationalized.** If not, explain why.  - NA
- [x] **README.md has been updated if needed.**
- [ ] **pom.xml version is set to the latest date** If not, explain why. - NA

## Assignee's Checklist
- [x] **All GitHub action checks have passed.**
- [x] **All reviewers have approved.**
- [x] **Relevant documentation has been updated if needed.**
- [ ] **pom.xml version is set to the latest date** If not, explain why.