### PR TITLE
Update README to allow support for custom branding and enforce reference to original project page

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,20 +4,17 @@
 
 Identify and sanitize sensitive information.
 
-## Features
- - Sanitizes HAR files.
- - Multiple files can be sanitized at the same time.<br>
- - Support for sanitizing SAML requests/responses are in progress.
-
-### Supported Browsers
+## Support
 The following browsers are supported:
- - Google Chrome
- - Firefox
+- Google Chrome
+- Firefox
+
+Multiple files can be sanitized at the same time.<br>
 
 ### Limitations
- - Maximum of 10 files can be sanitized at a time.
- - Each file cannot exceed 50 MB.
- - Only HAR files are supported.
+- Maximum of 10 files can be sanitized at a time.
+- Each file cannot exceed 50 MB.
+- Only HAR files are supported at the moment.
 
 ## Build
 To build the WASM code, run `build_wasm`.
@@ -30,6 +27,46 @@ To run tests, run `run_tests`.
 ```
 ./run_tests
 ```
+
+## Usage
+After building the WASM file, you can host the project as static content to be served on any HTTP server.
+
+### Host custom version
+
+#### Conditions
+- Do not modify or remove the following:
+    - `padaiyal` organization footer.
+    - [`LICENSE`](LICENSE) file.
+- Follow the terms and conditions of the [`LICENSE`](LICENSE).
+
+<br>
+You can host a custom version of this project with your own set of rules by:
+#### Forking this repository
+You can fork this repository to maintain you own version of this project.<br>
+Be sure to rebase on the latest changes periodically to pull in new bugfixes and features.
+
+#### Adding/Updating the rules.
+- The rule files can be found in the `rules` directory.<br>
+- There are separate rule files for each file format (Eg: `har.yaml`)<br>
+- For more info on writing rules refer to [rules/README.md](rules/README.md).<br>
+
+*NOTE: If the rules you'd be adding/updating would benefit a wider audience, please consider adding it to the original project via an issue & pull request.*
+
+#### Custom branding
+Please ensure you follow the [terms and conditions](#Conditions).
+##### Title
+To set a custom title:
+ - In `script/config.json`, set the `WebsiteTitle` value to the desired title text (Eg: `ABC Sanitizer Tool`).
+ - The recommended title text length is less than 30 characters.
+ - The title text is displayed as the tab title and in the navbar.
+##### Logo
+To use a custom logo for the tab and navbar:
+- In `script/config.json`, set the `WebsiteIconPath` value to the path of your image (Eg: `img/icon.png`).
+- The recommended minimum image resolution is 240x240.
+- Supported file formats: JPEG, PNG.
+
+#### Hosting
+You can host it on any web server or use GitHub pages to host directly from your fork.
 
 ## Demo
 The tool can be accessed [here](https://padaiyal.github.io/sanitizer/).

--- a/index.html
+++ b/index.html
@@ -3,8 +3,8 @@
     <head>
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">
-        <title>Sanitizer</title>
-        <link rel="icon" href="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>🧹</text></svg>">
+        <title id="title">Sanitizer</title>
+        <link id="tab_icon" rel="icon" href="">
         <meta name="theme-color" content="#fafafa">
         <!-- Custom styles -->
         <link href="css/style.css" rel="stylesheet" type="text/css" />
@@ -33,7 +33,10 @@
     <body onload="init()">
         <nav class="navbar fixed-top navbar-expand-lg navbar-dark bg-dark" style="padding: 10px">
             <div class="container-fluid" style="padding: 0;">
-                <a class="navbar-brand" href="#">🧹 Sensitive Info Sanitizer</a>
+                <a href="#" target="_blank" style="margin-right: 10px">
+                    <img id="navbar_icon" src="" style="width: 25px">
+                </a>
+                <a id="navbar_title" class="navbar-brand" href="#">Sensitive Info Sanitizer</a>
                 <form class="form-inline" style="margin-left: auto">
                     <input type="button" id="view_rules_button" class="btn btn-secondary" name="view_rules_button"
                            value="View Rules File/s" disabled>

--- a/rules/README.md
+++ b/rules/README.md
@@ -1,0 +1,33 @@
+# Sanitization rules
+
+The rules contain the patterns/specific fields and the approach to sanitize them.
+
+## Rule file
+Each rule file is in the yaml format stored as `rules/<file_extension>.yaml`.<br>
+For example, the rule file for HARs will be `rules/har.yaml`
+Each file can have one or more rules.
+
+### File format
+The format is as follows:
+```
+description: <Description of the file format and some info on the find of info sanitized.>
+format: <json>
+rules:
+    <json_path_pattern>:
+        description: <Information on what this rule sanitizes>
+        action: <contextual_replacement|remove>
+    ...
+```
+For an actual rule file, refer to [har.yaml](har.yaml)
+
+### Rule format
+As shown in the file format example above, a rule format looks like this:
+```
+<json_path_pattern>:
+    description: <Information on what this rule sanitizes>
+    action: <contextual_replacement|remove>
+```
+The `rules` section can contain one or more of these.
+The `action` for each rule can be one of the following:
+ - `contextual_replacement` - If this is chosen, during the sanitization of this file, the identical values are replaced with the same replacement value for context preservation. For example, there may be multiple rules sanitizing multiple fields with the sensitive value `topsecret`, and in this action it replaces all occurrences of `topsecret` with the same value.
+ - `remove` - Replaces the sensitive value with `<REMOVED>`.

--- a/script/config.json
+++ b/script/config.json
@@ -16,5 +16,7 @@
   "RemovedSecretReplacement": "<REMOVED>",
   "SecretPrefix": "secret",
   "SupportedFileExtensions":  ["har"],
-  "SupportedActions": ["contextual_replacement", "remove"]
+  "SupportedActions": ["contextual_replacement", "remove"],
+  "WebsiteTitle": "Sensitive Info Sanitizer",
+  "WebsiteIconPath": "data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>\uD83E\uDDF9</text></svg>"
 }

--- a/script/script.js
+++ b/script/script.js
@@ -8,8 +8,26 @@ function init() {
     console.log('Initializing...')
     fetch("script/config.json")
         .then(response => response.json())
-        .then((data) => {config = data;})
+        .then((data) => {
+            config = data;
+
+            const titleText = getConfig("WebsiteTitle", "Sensitive Info Sanitizer");
+            setTitle(titleText);
+
+            const iconPath = getConfig("WebsiteIconPath");
+            setIcon(iconPath);
+        })
         .catch(error => errorFollowUp(error));
+}
+
+function setTitle(titleText) {
+    document.getElementById("title").innerText = titleText;
+    document.getElementById("navbar_title").innerText = titleText;
+}
+
+function setIcon(iconPath) {
+    document.getElementById("tab_icon").setAttribute("href", iconPath);
+    document.getElementById("navbar_icon").setAttribute("src", iconPath);
 }
 
 function errorFollowUp(message) {


### PR DESCRIPTION
## Description
Closes #38.

Update README to allow support for custom branding (Logo & Title) along with requirement to link back to original project.

## Author's Checklist
- [x] **These changes don't break existing dependants.** If they do, and you suggest to proceed, 
please explain why.

## Reviewer's Checklist
- [ ] **All classes have documentation comments.** - NA
- [ ] **All methods have documentation comments.** - NA
- [ ] **No parameters are hardcoded.** Should be loaded as properties instead. If there needs to be hardcoded properties, explain why. - NA
- [ ] **All information to be logged/displayed to the user are internationalized.** If not, explain why. - NA
- [x] **README.md has been updated if needed.**
- [ ] **pom.xml version is set to the latest date** If not, explain why. - NA

## Assignee's Checklist
- [x] **All GitHub action checks have passed.**
- [x] **All reviewers have approved.**
- [x] **Relevant documentation has been updated if needed.**
- [ ] **pom.xml version is set to the latest date** If not, explain why. N/A